### PR TITLE
Adjusted getTemplate id to match exact template.

### DIFF
--- a/Vtexcms.js
+++ b/Vtexcms.js
@@ -452,7 +452,13 @@ class VtexCMS {
 	 */
 	_getTemplateId($, templateName) {
 
-		const currTemplate = $(`.template div:contains("${templateName}")`).next('a').attr('href');
+		const listMatch = $(`.template div:contains("${templateName}")`);
+
+		var match = listMatch.filter(function() {
+			return $(this).text() === `${templateName}`;
+		});
+
+		const currTemplate = match.next('a').attr('href');
 
 		try {
 			currTemplate.match(/(templateId=)(.+)$/)[2];


### PR DESCRIPTION
const currTemplate = $(`.template div:contains("${templateName}")`).next('a').attr('href');

Em casos onde existem templates com nomes semelhantes, o seletor :contains retorna uma lista, portando o método next, apenas seleciona o primeiro item desta lista, causando download de templates errados, impedindo upload futuro.